### PR TITLE
Use static method constructor, templated functions

### DIFF
--- a/src/mattress/__init__.py
+++ b/src/mattress/__init__.py
@@ -15,7 +15,4 @@ except PackageNotFoundError:  # pragma: no cover
 finally:
     del version, PackageNotFoundError
 
-from .core import (
-    TatamiNumericPointer,
-    py_initialize_dense_matrix
-)
+from .core import TatamiNumericPointer

--- a/src/mattress/interface.py
+++ b/src/mattress/interface.py
@@ -3,7 +3,7 @@ from typing import Any
 
 import numpy as np
 
-from .core import TatamiNumericPointer, py_initialize_dense_matrix
+from .core import TatamiNumericPointer
 from .utils import map_order_to_bool
 
 __author__ = "jkanche"
@@ -27,11 +27,11 @@ def tatamize(x: Any, order: str = "C") -> TatamiNumericPointer:
         TatamiNumericPointer: a pointer to tatami object.
     """
     raise NotImplementedError(
-        f"tatamize  is not supported for objects of class: {type(x)}"
+        f"tatamize is not supported for objects of class: {type(x)}"
     )
 
 
 @tatamize.register
 def _tatamize_numpy(x: np.ndarray, order: str = "C") -> TatamiNumericPointer:
     order_to_bool = map_order_to_bool(order=order)
-    return py_initialize_dense_matrix(x.shape[0], x.shape[1], x, order_to_bool)
+    return TatamiNumericPointer.from_dense(x.shape[0], x.shape[1], x, order_to_bool)

--- a/src/mattress/lib/bindings.pxd
+++ b/src/mattress/lib/bindings.pxd
@@ -1,12 +1,15 @@
 from libcpp cimport bool
-from libc.stdint cimport (uintptr_t, int64_t, uint64_t, int32_t, uint32_t, int16_t, uint16_t, int8_t, uint8_t)
+
+cdef extern from "cpp/Mattress.h":
+    ctypedef struct Mattress:
+        pass
 
 cdef extern from "cpp/common.cpp":
-    int extract_nrow(uintptr_t)
-    int extract_ncol(uintptr_t)
-    bool extract_sparse(uintptr_t)
-    void extract_row(uintptr_t, int, double*);
-    void extract_column(uintptr_t, int, double*);
+    int extract_nrow(Mattress*)
+    int extract_ncol(Mattress*)
+    bool extract_sparse(Mattress*)
+    void extract_row(Mattress*, int, double*);
+    void extract_column(Mattress*, int, double*);
 
 cdef extern from "cpp/dense.cpp":
-    uintptr_t initialize_dense_matrix[T](int, int, T*, bool)
+    Mattress* initialize_dense_matrix[T](int, int, T*, bool)

--- a/src/mattress/lib/bindings.pxd
+++ b/src/mattress/lib/bindings.pxd
@@ -10,6 +10,7 @@ cdef extern from "cpp/common.cpp":
     bool extract_sparse(Mattress*)
     void extract_row(Mattress*, int, double*);
     void extract_column(Mattress*, int, double*);
+    void free_mat(Mattress*);
 
 cdef extern from "cpp/dense.cpp":
     Mattress* initialize_dense_matrix[T](int, int, T*, bool)

--- a/src/mattress/lib/bindings.pxd
+++ b/src/mattress/lib/bindings.pxd
@@ -9,14 +9,4 @@ cdef extern from "cpp/common.cpp":
     void extract_column(uintptr_t, int, double*);
 
 cdef extern from "cpp/dense.cpp":
-    uintptr_t initialize_dense_matrix(int, int, float*, bool)
-    uintptr_t initialize_dense_matrix(int, int, double*, bool)
-    uintptr_t initialize_dense_matrix(int, int, signed long long*, bool) # ??? I dunno, int64_t doesn't work.
-    uintptr_t initialize_dense_matrix(int, int, int64_t*, bool)
-    uintptr_t initialize_dense_matrix(int, int, uint64_t*, bool)
-    uintptr_t initialize_dense_matrix(int, int, int32_t*, bool)
-    uintptr_t initialize_dense_matrix(int, int, uint32_t*, bool)
-    uintptr_t initialize_dense_matrix(int, int, int16_t*, bool)
-    uintptr_t initialize_dense_matrix(int, int, uint16_t*, bool)
-    uintptr_t initialize_dense_matrix(int, int, int8_t*, bool)
-    uintptr_t initialize_dense_matrix(int, int, uint8_t*, bool)
+    uintptr_t initialize_dense_matrix[T](int, int, T*, bool)

--- a/src/mattress/lib/bindings.pyx
+++ b/src/mattress/lib/bindings.pyx
@@ -1,4 +1,5 @@
 from bindings cimport (
+    Mattress,
     extract_nrow,
     extract_ncol,
     extract_sparse,
@@ -7,18 +8,12 @@ from bindings cimport (
     initialize_dense_matrix
 )
 from libcpp cimport bool
-from libc.stdint cimport uintptr_t
-from cython.operator cimport dereference
-cimport numpy as np
 import numpy as np
+cimport numpy as np
 
 cdef class TatamiNumericPointer:
-    cdef uintptr_t ptr
+    cdef Mattress* ptr
     cdef object obj # held to prevent garbage collection.
-
-    def __init__(self, uintptr_t ptr, obj):
-        self.ptr = ptr
-        self.obj = obj
 
     def nrow(self):
         return extract_nrow(self.ptr);
@@ -41,52 +36,54 @@ cdef class TatamiNumericPointer:
         extract_column(self.ptr, c, &myarr[0]);
         return myarr
 
-def py_initialize_dense_matrix(int nr, int nc, np.ndarray arr, bool byrow):
-    cdef TatamiNumericPointer output;
+    @staticmethod
+    def from_dense(int nr, int nc, np.ndarray arr, bool byrow):
+        cdef TatamiNumericPointer output = TatamiNumericPointer.__new__(TatamiNumericPointer)
 
-    # Defining everything here because otherwise Cython complains about scoping.
-    cdef np.float64_t[:,:] view_f64
-    cdef np.float32_t[:,:] view_f32
-    cdef np.int64_t[:,:] view_i64
-    cdef np.int32_t[:,:] view_i32
-    cdef np.int16_t[:,:] view_i16
-    cdef np.int8_t[:,:] view_i8
-    cdef np.uint64_t[:,:] view_u64
-    cdef np.uint32_t[:,:] view_u32
-    cdef np.uint16_t[:,:] view_u16
-    cdef np.uint8_t[:,:] view_u8
+        # Defining everything here because otherwise Cython complains about scoping.
+        cdef np.float64_t[:,:] view_f64
+        cdef np.float32_t[:,:] view_f32
+        cdef np.int64_t[:,:] view_i64
+        cdef np.int32_t[:,:] view_i32
+        cdef np.int16_t[:,:] view_i16
+        cdef np.int8_t[:,:] view_i8
+        cdef np.uint64_t[:,:] view_u64
+        cdef np.uint32_t[:,:] view_u32
+        cdef np.uint16_t[:,:] view_u16
+        cdef np.uint8_t[:,:] view_u8
 
-    if arr.dtype == np.float64:
-        view_f64 = arr
-        output = TatamiNumericPointer(initialize_dense_matrix(nr, nc, &(view_f64[0,0]), byrow), arr)
-    elif arr.dtype == np.float32:
-        view_f32 = arr
-        output = TatamiNumericPointer(initialize_dense_matrix(nr, nc, &(view_f32[0,0]), byrow), arr)
-    elif arr.dtype == np.int64:
-        view_i64 = arr
-        output = TatamiNumericPointer(initialize_dense_matrix(nr, nc, &(view_i64[0,0]), byrow), arr)
-    elif arr.dtype == np.int32:
-        view_i32 = arr
-        output = TatamiNumericPointer(initialize_dense_matrix(nr, nc, &(view_i32[0,0]), byrow), arr)
-    elif arr.dtype == np.int16:
-        view_i16 = arr
-        output = TatamiNumericPointer(initialize_dense_matrix(nr, nc, &(view_i16[0,0]), byrow), arr)
-    elif arr.dtype == np.int8:
-        view_i8 = arr
-        output = TatamiNumericPointer(initialize_dense_matrix(nr, nc, &(view_i8[0,0]), byrow), arr)
-    elif arr.dtype == np.uint64:
-        view_u64 = arr
-        output = TatamiNumericPointer(initialize_dense_matrix(nr, nc, &(view_u64[0,0]), byrow), arr)
-    elif arr.dtype == np.uint32:
-        view_u32 = arr
-        output = TatamiNumericPointer(initialize_dense_matrix(nr, nc, &(view_u32[0,0]), byrow), arr)
-    elif arr.dtype == np.uint16:
-        view_u16 = arr
-        output = TatamiNumericPointer(initialize_dense_matrix(nr, nc, &(view_u16[0,0]), byrow), arr)
-    elif arr.dtype == np.uint8:
-        view_u8 = arr
-        output = TatamiNumericPointer(initialize_dense_matrix(nr, nc, &(view_u8[0,0]), byrow), arr)
-    else:
-        raise TypeError("unsupported numpy type for dense matrix initialization")
+        if arr.dtype == np.float64:
+            view_f64 = arr
+            output.ptr = initialize_dense_matrix(nr, nc, &(view_f64[0,0]), byrow)
+        elif arr.dtype == np.float32:
+            view_f32 = arr
+            output.ptr = initialize_dense_matrix(nr, nc, &(view_f32[0,0]), byrow)
+        elif arr.dtype == np.int64:
+            view_i64 = arr
+            output.ptr = initialize_dense_matrix(nr, nc, &(view_i64[0,0]), byrow)
+        elif arr.dtype == np.int32:
+            view_i32 = arr
+            output.ptr = initialize_dense_matrix(nr, nc, &(view_i32[0,0]), byrow)
+        elif arr.dtype == np.int16:
+            view_i16 = arr
+            output.ptr = initialize_dense_matrix(nr, nc, &(view_i16[0,0]), byrow)
+        elif arr.dtype == np.int8:
+            view_i8 = arr
+            output.ptr = initialize_dense_matrix(nr, nc, &(view_i8[0,0]), byrow)
+        elif arr.dtype == np.uint64:
+            view_u64 = arr
+            output.ptr = initialize_dense_matrix(nr, nc, &(view_u64[0,0]), byrow)
+        elif arr.dtype == np.uint32:
+            view_u32 = arr
+            output.ptr = initialize_dense_matrix(nr, nc, &(view_u32[0,0]), byrow)
+        elif arr.dtype == np.uint16:
+            view_u16 = arr
+            output.ptr = initialize_dense_matrix(nr, nc, &(view_u16[0,0]), byrow)
+        elif arr.dtype == np.uint8:
+            view_u8 = arr
+            output.ptr = initialize_dense_matrix(nr, nc, &(view_u8[0,0]), byrow)
+        else:
+            raise TypeError("unsupported numpy type for dense matrix initialization")
 
-    return output
+        output.obj = arr
+        return output

--- a/src/mattress/lib/bindings.pyx
+++ b/src/mattress/lib/bindings.pyx
@@ -5,6 +5,7 @@ from bindings cimport (
     extract_sparse,
     extract_row,
     extract_column,
+    free_mat,
     initialize_dense_matrix
 )
 from libcpp cimport bool
@@ -14,6 +15,9 @@ cimport numpy as np
 cdef class TatamiNumericPointer:
     cdef Mattress* ptr
     cdef object obj # held to prevent garbage collection.
+
+    def __dealloc__(self):
+        free_mat(self.ptr)
 
     def nrow(self):
         return extract_nrow(self.ptr);

--- a/src/mattress/lib/cpp/common.cpp
+++ b/src/mattress/lib/cpp/common.cpp
@@ -19,3 +19,7 @@ inline void extract_row(Mattress* mat, int r, double* output) {
 inline void extract_column(Mattress* mat, int c, double* output) {
     mat->column()->fetch_copy(c, output);
 }
+
+inline void free_mat(Mattress* mat) {
+    delete mat;
+}

--- a/src/mattress/lib/cpp/common.cpp
+++ b/src/mattress/lib/cpp/common.cpp
@@ -1,21 +1,21 @@
 #include "Mattress.h"
 
-inline int extract_nrow(uintptr_t mat) {
-    return reinterpret_cast<Mattress*>(mat)->ptr->nrow();
+inline int extract_nrow(const Mattress* mat) {
+    return mat->ptr->nrow();
 }
 
-inline int extract_ncol(uintptr_t mat) {
-    return reinterpret_cast<Mattress*>(mat)->ptr->ncol();
+inline int extract_ncol(const Mattress* mat) {
+    return mat->ptr->ncol();
 }
 
-inline bool extract_sparse(uintptr_t mat) {
-    return reinterpret_cast<Mattress*>(mat)->ptr->sparse();
+inline bool extract_sparse(const Mattress* mat) {
+    return mat->ptr->sparse();
 }
 
-inline void extract_row(uintptr_t mat, int r, double* output) {
-    reinterpret_cast<Mattress*>(mat)->row()->fetch_copy(r, output);
+inline void extract_row(Mattress* mat, int r, double* output) {
+    mat->row()->fetch_copy(r, output);
 }
 
-inline void extract_column(uintptr_t mat, int c, double* output) {
-    reinterpret_cast<Mattress*>(mat)->column()->fetch_copy(c, output);
+inline void extract_column(Mattress* mat, int c, double* output) {
+    mat->column()->fetch_copy(c, output);
 }

--- a/src/mattress/lib/cpp/dense.cpp
+++ b/src/mattress/lib/cpp/dense.cpp
@@ -1,11 +1,11 @@
 #include "Mattress.h"
 
 template<typename T>
-inline uintptr_t initialize_dense_matrix(int nr, int nc, const T* ptr, bool byrow) { 
+inline Mattress* initialize_dense_matrix(int nr, int nc, const T* ptr, bool byrow) { 
     tatami::ArrayView<T> view(ptr, static_cast<size_t>(nr) * static_cast<size_t>(nc));
     if (byrow) {
-        return reinterpret_cast<uintptr_t>(new Mattress(new tatami::DenseRowMatrix<double, int, decltype(view)>(nr, nc, view)));
+        return new Mattress(new tatami::DenseRowMatrix<double, int, decltype(view)>(nr, nc, view));
     } else {
-        return reinterpret_cast<uintptr_t>(new Mattress(new tatami::DenseColumnMatrix<double, int, decltype(view)>(nr, nc, view)));
+        return new Mattress(new tatami::DenseColumnMatrix<double, int, decltype(view)>(nr, nc, view));
     }
 }

--- a/src/mattress/lib/cpp/dense.cpp
+++ b/src/mattress/lib/cpp/dense.cpp
@@ -1,55 +1,11 @@
 #include "Mattress.h"
 
 template<typename T>
-inline uintptr_t initialize_dense_matrix_core(int nr, int nc, const T* ptr, bool byrow) { 
+inline uintptr_t initialize_dense_matrix(int nr, int nc, const T* ptr, bool byrow) { 
     tatami::ArrayView<T> view(ptr, static_cast<size_t>(nr) * static_cast<size_t>(nc));
     if (byrow) {
         return reinterpret_cast<uintptr_t>(new Mattress(new tatami::DenseRowMatrix<double, int, decltype(view)>(nr, nc, view)));
     } else {
         return reinterpret_cast<uintptr_t>(new Mattress(new tatami::DenseColumnMatrix<double, int, decltype(view)>(nr, nc, view)));
     }
-}
-
-inline uintptr_t initialize_dense_matrix(int nr, int nc, const double* ptr, bool byrow) { 
-    return initialize_dense_matrix_core(nr, nc, ptr, byrow);
-}
-
-inline uintptr_t initialize_dense_matrix(int nr, int nc, const float* ptr, bool byrow) { 
-    return initialize_dense_matrix_core(nr, nc, ptr, byrow);
-}
-
-inline uintptr_t initialize_dense_matrix(int nr, int nc, const signed long long* ptr, bool byrow) { 
-    return initialize_dense_matrix_core(nr, nc, ptr, byrow);
-}
-
-inline uintptr_t initialize_dense_matrix(int nr, int nc, const int64_t* ptr, bool byrow) { 
-    return initialize_dense_matrix_core(nr, nc, ptr, byrow);
-}
-
-inline uintptr_t initialize_dense_matrix(int nr, int nc, const uint64_t* ptr, bool byrow) { 
-    return initialize_dense_matrix_core(nr, nc, ptr, byrow);
-}
-
-inline uintptr_t initialize_dense_matrix(int nr, int nc, const int32_t* ptr, bool byrow) { 
-    return initialize_dense_matrix_core(nr, nc, ptr, byrow);
-}
-
-inline uintptr_t initialize_dense_matrix(int nr, int nc, const uint32_t* ptr, bool byrow) { 
-    return initialize_dense_matrix_core(nr, nc, ptr, byrow);
-}
-
-inline uintptr_t initialize_dense_matrix(int nr, int nc, const int16_t* ptr, bool byrow) { 
-    return initialize_dense_matrix_core(nr, nc, ptr, byrow);
-}
-
-inline uintptr_t initialize_dense_matrix(int nr, int nc, const uint16_t* ptr, bool byrow) { 
-    return initialize_dense_matrix_core(nr, nc, ptr, byrow);
-}
-
-inline uintptr_t initialize_dense_matrix(int nr, int nc, const int8_t* ptr, bool byrow) { 
-    return initialize_dense_matrix_core(nr, nc, ptr, byrow);
-}
-
-inline uintptr_t initialize_dense_matrix(int nr, int nc, const uint8_t* ptr, bool byrow) { 
-    return initialize_dense_matrix_core(nr, nc, ptr, byrow);
 }


### PR DESCRIPTION
Should make things a bit more natural, cut down on a lot of code.

```python
import numpy as np
import mattress

y = np.random.rand(1000, 100)
ptr = mattress.TatamiNumericPointer.from_dense(y.shape[0], y.shape[1], y, True)
ptr.row(0) # same as y[0,:]
ptr.column(1) # same as y[:,1]
```