### PR TITLE
Initial support for sparse matrices.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,11 @@ if __name__ == "__main__":
             ext_modules=[
                 Extension(
                     "mattress.core",
-                    ["src/mattress/lib/dense.cpp", "src/mattress/lib/common.cpp"],
+                    [
+                        "src/mattress/lib/dense.cpp", 
+                        "src/mattress/lib/compressed_sparse.cpp", 
+                        "src/mattress/lib/common.cpp"
+                    ],
                     include_dirs=[
                         "src/mattress/extern/tatami/include",
                         "src/mattress/include",

--- a/src/mattress/TatamiNumericPointer.py
+++ b/src/mattress/TatamiNumericPointer.py
@@ -79,14 +79,11 @@ class TatamiNumericPointer:
         return output
 
     @classmethod
-    def from_dense_matrix(
-        cls, x: np.ndarray, dtype: str, order: bool
-    ) -> "TatamiNumericPointer":
+    def from_dense_matrix(cls, x: np.ndarray, order: bool) -> "TatamiNumericPointer":
         """Initialize class from a dense matrix.
 
         Args:
             x (np.ndarray): input numpy matrix.
-            dtype (str): dtype of the values.
             order (bool): True if order is 'C' else False.
 
         Returns:
@@ -94,7 +91,11 @@ class TatamiNumericPointer:
         """
         return cls(
             ptr=lib.py_initialize_dense_matrix(
-                x.shape[0], x.shape[1], dtype, x.ctypes.data, order
+                x.shape[0],
+                x.shape[1],
+                str(x.dtype).encode("utf-8"),
+                x.ctypes.data,
+                order,
             ),
             obj=x,
         )

--- a/src/mattress/cpphelpers.py
+++ b/src/mattress/cpphelpers.py
@@ -61,3 +61,16 @@ lib.py_initialize_dense_matrix.argtypes = [
     ct.c_void_p,
     ct.c_char,
 ]
+
+lib.py_initialize_compressed_sparse_matrix.restype = ct.c_void_p
+lib.py_initialize_compressed_sparse_matrix.argtypes = [
+    ct.c_int,
+    ct.c_int,
+    ct.c_uint64,
+    ct.c_char_p,
+    ct.c_void_p,
+    ct.c_char_p,
+    ct.c_void_p,
+    ct.c_void_p,
+    ct.c_uint8,
+]

--- a/src/mattress/interface.py
+++ b/src/mattress/interface.py
@@ -2,6 +2,7 @@ from functools import singledispatch
 from typing import Any
 
 import numpy as np
+import scipy.sparse as sp
 
 from .TatamiNumericPointer import TatamiNumericPointer
 from .utils import map_order_to_bool
@@ -47,5 +48,68 @@ def _tatamize_numpy(x: np.ndarray, order: str = "C") -> TatamiNumericPointer:
         TatamiNumericPointer: a pointer to tatami object.
     """
     order_to_bool = map_order_to_bool(order=order)
-    dtype = str(x.dtype).encode("utf-8")
-    return TatamiNumericPointer.from_dense_matrix(x, dtype=dtype, order=order_to_bool)
+    return TatamiNumericPointer.from_dense_matrix(x, order=order_to_bool)
+
+
+@tatamize.register
+def _tatamize_sparse_csr_array(x: sp.csr_array) -> TatamiNumericPointer:
+    """Converts scipy's CSR representations to tatami.
+
+    Args:
+        x (sp.csr_array): A scipy csr array.
+
+    Raises:
+        NotImplementedError: if x is not supported.
+
+    Returns:
+        TatamiNumericPointer: a pointer to tatami object.
+    """
+    return TatamiNumericPointer.from_csr_array(x)
+
+
+@tatamize.register
+def _tatamize_sparse_csr_matrix(x: sp.csr_matrix) -> TatamiNumericPointer:
+    """Converts scipy's CSR representations to tatami.
+
+    Args:
+        x (sp.csr_matrix): A scipy csr array.
+
+    Raises:
+        NotImplementedError: if x is not supported.
+
+    Returns:
+        TatamiNumericPointer: a pointer to tatami object.
+    """
+    return TatamiNumericPointer.from_csr_array(x)
+
+
+@tatamize.register
+def _tatamize_sparse_csc_array(x: sp.csc_array) -> TatamiNumericPointer:
+    """Converts scipy's CSC representations to tatami.
+
+    Args:
+        x (sp.csc_array): A scipy csc array.
+
+    Raises:
+        NotImplementedError: if x is not supported.
+
+    Returns:
+        TatamiNumericPointer: a pointer to tatami object.
+    """
+    return TatamiNumericPointer.from_csc_array(x)
+
+
+@tatamize.register
+def _tatamize_sparse_csc_matrix(x: sp.csc_matrix) -> TatamiNumericPointer:
+    """Converts scipy's CSC representations to tatami.
+
+    Args:
+        x (sp.csc_matrix): A scipy csc array.
+
+    Raises:
+        NotImplementedError: if x is not supported.
+
+    Returns:
+        TatamiNumericPointer: a pointer to tatami object.
+    """
+    return TatamiNumericPointer.from_csc_array(x)

--- a/src/mattress/lib/compressed_sparse.cpp
+++ b/src/mattress/lib/compressed_sparse.cpp
@@ -1,0 +1,91 @@
+#include "Mattress.h"
+#include <string>
+#include <stdexcept>
+#include <cstring>
+#include <cstdint>
+
+template<typename Data_, typename Index_>
+Mattress* initialize_compressed_sparse_matrix(int nr, int nc, uint64_t nz, const Data_* dptr, const Index_* iptr, void* indptr, uint8_t byrow) { 
+    tatami::ArrayView<Data_> dview(dptr, nz);
+    tatami::ArrayView<Index_> iview(iptr, nz);
+    tatami::ArrayView<uint64_t> pview(reinterpret_cast<uint64_t*>(indptr), (byrow ? nr : nc) + 1);
+
+    // Disabling checks for speed.
+    if (byrow) {
+        return new Mattress(new tatami::CompressedSparseRowMatrix<double, int, decltype(dview), decltype(iview), decltype(pview)>(nr, nc, std::move(dview), std::move(iview), std::move(pview), false));
+    } else {
+        return new Mattress(new tatami::CompressedSparseColumnMatrix<double, int, decltype(dview), decltype(iview), decltype(pview)>(nr, nc, std::move(dview), std::move(iview), std::move(pview), false));
+    }
+}
+
+template<typename Data_>
+Mattress* initialize_compressed_sparse_matrix_itype(int nr, int nc, uint64_t nz, const Data_* dptr, const char* itype, void* iptr, void* indptr, uint8_t byrow) {
+    if (std::strcmp(itype, "int64") == 0) {
+        return initialize_compressed_sparse_matrix(nr, nc, nz, dptr, reinterpret_cast< int64_t*>(iptr), indptr, byrow);
+
+    } else if (std::strcmp(itype, "int32") == 0) {
+        return initialize_compressed_sparse_matrix(nr, nc, nz, dptr, reinterpret_cast< int32_t*>(iptr), indptr, byrow);
+
+    } else if (std::strcmp(itype, "int16") == 0) {
+        return initialize_compressed_sparse_matrix(nr, nc, nz, dptr, reinterpret_cast< int16_t*>(iptr), indptr, byrow);
+
+    } else if (std::strcmp(itype, "int8") == 0) {
+        return initialize_compressed_sparse_matrix(nr, nc, nz, dptr, reinterpret_cast<  int8_t*>(iptr), indptr, byrow);
+
+    } else if (std::strcmp(itype, "uint64") == 0) {
+        return initialize_compressed_sparse_matrix(nr, nc, nz, dptr, reinterpret_cast<uint64_t*>(iptr), indptr, byrow);
+
+    } else if (std::strcmp(itype, "uint32") == 0) {
+        return initialize_compressed_sparse_matrix(nr, nc, nz, dptr, reinterpret_cast<uint32_t*>(iptr), indptr, byrow);
+
+    } else if (std::strcmp(itype, "uint16") == 0) {
+        return initialize_compressed_sparse_matrix(nr, nc, nz, dptr, reinterpret_cast<uint16_t*>(iptr), indptr, byrow);
+
+    } else if (std::strcmp(itype, "uint8") == 0) {
+        return initialize_compressed_sparse_matrix(nr, nc, nz, dptr, reinterpret_cast< uint8_t*>(iptr), indptr, byrow);
+    }
+
+    throw std::runtime_error("unrecognized type '" + std::string(itype) + "' for sparse matrix indices");
+    return NULL;
+}
+
+extern "C" {
+
+Mattress* py_initialize_compressed_sparse_matrix(int nr, int nc, uint64_t nz, const char* dtype, void* dptr, const char* itype, void* iptr, void* indptr, uint8_t byrow) {
+    if (std::strcmp(dtype, "float64") == 0) {
+        return initialize_compressed_sparse_matrix_itype(nr, nc, nz, reinterpret_cast<  double*>(dptr), itype, iptr, indptr, byrow);
+
+    } else if (std::strcmp(dtype, "float32") == 0) {
+        return initialize_compressed_sparse_matrix_itype(nr, nc, nz, reinterpret_cast<   float*>(dptr), itype, iptr, indptr, byrow);
+
+    } else if (std::strcmp(dtype, "int64") == 0) {
+        return initialize_compressed_sparse_matrix_itype(nr, nc, nz, reinterpret_cast< int64_t*>(dptr), itype, iptr, indptr, byrow);
+
+    } else if (std::strcmp(dtype, "int32") == 0) {
+        return initialize_compressed_sparse_matrix_itype(nr, nc, nz, reinterpret_cast< int32_t*>(dptr), itype, iptr, indptr, byrow);
+
+    } else if (std::strcmp(dtype, "int16") == 0) {
+        return initialize_compressed_sparse_matrix_itype(nr, nc, nz, reinterpret_cast< int16_t*>(dptr), itype, iptr, indptr, byrow);
+
+    } else if (std::strcmp(dtype, "int8") == 0) {
+        return initialize_compressed_sparse_matrix_itype(nr, nc, nz, reinterpret_cast<  int8_t*>(dptr), itype, iptr, indptr, byrow);
+
+    } else if (std::strcmp(dtype, "uint64") == 0) {
+        return initialize_compressed_sparse_matrix_itype(nr, nc, nz, reinterpret_cast<uint64_t*>(dptr), itype, iptr, indptr, byrow);
+
+    } else if (std::strcmp(dtype, "uint32") == 0) {
+        return initialize_compressed_sparse_matrix_itype(nr, nc, nz, reinterpret_cast<uint32_t*>(dptr), itype, iptr, indptr, byrow);
+
+    } else if (std::strcmp(dtype, "uint16") == 0) {
+        return initialize_compressed_sparse_matrix_itype(nr, nc, nz, reinterpret_cast<uint16_t*>(dptr), itype, iptr, indptr, byrow);
+
+    } else if (std::strcmp(dtype, "uint8") == 0) {
+        return initialize_compressed_sparse_matrix_itype(nr, nc, nz, reinterpret_cast< uint8_t*>(dptr), itype, iptr, indptr, byrow);
+    }
+
+    throw std::runtime_error("unrecognized array type '" + std::string(dtype) + "' for sparse matrix data");
+    return NULL;
+}
+
+}
+

--- a/tests/test_sparse.py
+++ b/tests/test_sparse.py
@@ -9,26 +9,26 @@ __license__ = "MIT"
 def test_sparse_csr_matrix():
     m = rand(3, 4, density=0.25, format="csr", random_state=42)
     ptr = tatamize(m)
-    assert all(ptr.row(0) == m[0, :])
-    assert all(ptr.column(1) == m[:, 1])
+    assert all(ptr.row(0) == m[0, :].toarray()[0])
+    assert all(ptr.column(1) == m[:, 1].toarray()[0])
 
 
 def test_sparse_csr_array():
     m = rand(3, 4, density=0.25, format="csr", random_state=42).tocsr()
     ptr = tatamize(m)
-    assert all(ptr.row(0) == m[0, :])
-    assert all(ptr.column(1) == m[:, 1])
+    assert all(ptr.row(0) == m[0, :].toarray()[0])
+    assert all(ptr.column(1) == m[:, 1].toarray()[0])
 
 
 def test_sparse_csc_matrix():
     m = rand(3, 4, density=0.25, format="csc", random_state=42)
     ptr = tatamize(m)
-    assert all(ptr.row(0) == m[0, :])
-    assert all(ptr.column(1) == m[:, 1])
+    assert all(ptr.row(0) == m[0, :].toarray()[0])
+    assert all(ptr.column(1) == m[:, 1].toarray()[0])
 
 
 def test_sparse_csc_array():
     m = rand(3, 4, density=0.25, format="csc", random_state=42).tocsc()
     ptr = tatamize(m)
-    assert all(ptr.row(0) == m[0, :])
-    assert all(ptr.column(1) == m[:, 1])
+    assert all(ptr.row(0) == m[0, :].toarray()[0])
+    assert all(ptr.column(1) == m[:, 1].toarray()[0])

--- a/tests/test_sparse.py
+++ b/tests/test_sparse.py
@@ -6,15 +6,29 @@ __copyright__ = "ltla, jkanche"
 __license__ = "MIT"
 
 
-def test_sparse_csr():
+def test_sparse_csr_matrix():
     m = rand(3, 4, density=0.25, format="csr", random_state=42)
     ptr = tatamize(m)
     assert all(ptr.row(0) == m[0, :])
     assert all(ptr.column(1) == m[:, 1])
 
 
-def test_sparse_csc():
+def test_sparse_csr_array():
+    m = rand(3, 4, density=0.25, format="csr", random_state=42).tocsr()
+    ptr = tatamize(m)
+    assert all(ptr.row(0) == m[0, :])
+    assert all(ptr.column(1) == m[:, 1])
+
+
+def test_sparse_csc_matrix():
     m = rand(3, 4, density=0.25, format="csc", random_state=42)
+    ptr = tatamize(m)
+    assert all(ptr.row(0) == m[0, :])
+    assert all(ptr.column(1) == m[:, 1])
+
+
+def test_sparse_csc_array():
+    m = rand(3, 4, density=0.25, format="csc", random_state=42).tocsc()
     ptr = tatamize(m)
     assert all(ptr.row(0) == m[0, :])
     assert all(ptr.column(1) == m[:, 1])

--- a/tests/test_sparse.py
+++ b/tests/test_sparse.py
@@ -1,0 +1,20 @@
+from mattress import tatamize
+from scipy.sparse import rand
+
+__author__ = "ltla, jkanche"
+__copyright__ = "ltla, jkanche"
+__license__ = "MIT"
+
+
+def test_sparse_csr():
+    m = rand(3, 4, density=0.25, format="csr", random_state=42)
+    ptr = tatamize(m)
+    assert all(ptr.row(0) == m[0, :])
+    assert all(ptr.column(1) == m[:, 1])
+
+
+def test_sparse_csc():
+    m = rand(3, 4, density=0.25, format="csc", random_state=42)
+    ptr = tatamize(m)
+    assert all(ptr.row(0) == m[0, :])
+    assert all(ptr.column(1) == m[:, 1])


### PR DESCRIPTION
This involves adding some Python objects to the TatamiNumericPointer to protect the underlying data from the GC (and subsequent invalidation of C++ views held inside the tatami pointer).