### PR TITLE
Implement delayedarray generics

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -50,9 +50,9 @@ package_dir =
 install_requires =
     importlib-metadata; python_version<"3.8"
     numpy>=1.22.4
-    scipy
     delayedarray>=0.5.0,<0.6.0
     assorthead>=0.0.7
+    biocutils
 
 
 [options.packages.find]
@@ -70,6 +70,7 @@ testing =
     setuptools
     pytest
     pytest-cov
+    scipy
 
 [options.entry_points]
 # Add here console scripts like:

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,7 @@ install_requires =
     importlib-metadata; python_version<"3.8"
     numpy>=1.22.4
     scipy
-    delayedarray
+    delayedarray>=0.5.0,<0.6.0
     assorthead>=0.0.7
 
 

--- a/src/mattress/TatamiNumericPointer.py
+++ b/src/mattress/TatamiNumericPointer.py
@@ -2,6 +2,7 @@ from numpy import ndarray, float64, int32, zeros, dtype
 from . import _cpphelpers as lib
 from typing import Tuple, Sequence
 from .utils import _sanitize_subset
+from delayedarray import is_sparse, extract_dense_array, extract_sparse_array
 
 __author__ = "ltla, jkanche"
 __copyright__ = "ltla, jkanche"
@@ -73,7 +74,7 @@ class TatamiNumericPointer:
         lib.extract_dense_full(self.ptr, output.ctypes.data)
         return output
 
-    def __DelayedArray_extract__(self, subset: Tuple[Sequence[int], ...]) -> ndarray:
+    def __generic_extract__(self, subset: Tuple[Sequence[int], ...]) -> ndarray:
         """Enable DelayedArray extraction of subsets of data from the matrix.
 
         See :py:meth:`~delayedarray.DelayedArray.DelayedArray.__DelayedArray_extract__` for details.
@@ -454,3 +455,20 @@ class TatamiNumericPointer:
             self.ptr, ind.ctypes.data, output.ctypes.data, num_threads
         )
         return output.T, lev
+
+
+@is_sparse.register
+def is_sparse_tatami(x: TatamiNumericPointer):
+    return x.sparse()
+
+
+@extract_dense_array.register
+def extract_dense_array_tatami(x: TatamiNumericPointer, subset: Tuple[Sequence[int], ...]) -> TatamiNumericPointer:
+    """See :py:meth:`~delayedarray.extract_dense_array.extract_dense_array`."""
+    return x.__generic_extract__(subset=subset)
+
+
+@extract_sparse_array.register
+def extract_sparse_array_tatami(x: TatamiNumericPointer, subset: Tuple[Sequence[int], ...]) -> TatamiNumericPointer:
+    """See :py:meth:`~delayedarray.extract_sparse_array.extract_sparse_array`."""
+    return x.__generic_extract__(subset=subset)

--- a/src/mattress/TatamiNumericPointer.py
+++ b/src/mattress/TatamiNumericPointer.py
@@ -2,7 +2,7 @@ from numpy import ndarray, float64, int32, zeros, dtype
 from . import _cpphelpers as lib
 from typing import Tuple, Sequence
 from .utils import _sanitize_subset
-from delayedarray import is_sparse, extract_dense_array, extract_sparse_array
+from delayedarray import is_sparse, extract_dense_array, extract_sparse_array, is_masked
 
 __author__ = "ltla, jkanche"
 __copyright__ = "ltla, jkanche"
@@ -472,3 +472,9 @@ def extract_dense_array_tatami(x: TatamiNumericPointer, subset: Tuple[Sequence[i
 def extract_sparse_array_tatami(x: TatamiNumericPointer, subset: Tuple[Sequence[int], ...]) -> TatamiNumericPointer:
     """See :py:meth:`~delayedarray.extract_sparse_array.extract_sparse_array`."""
     return x.__generic_extract__(subset=subset)
+
+
+@is_masked.register
+def is_masked_tatami(x: TatamiNumericPointer) -> bool:
+    """See :py:meth:`~delayedarray.is_masked.is_masked`."""
+    return False

--- a/src/mattress/TatamiNumericPointer.py
+++ b/src/mattress/TatamiNumericPointer.py
@@ -2,7 +2,7 @@ from numpy import ndarray, float64, int32, zeros, dtype
 from . import _cpphelpers as lib
 from typing import Tuple, Sequence
 from .utils import _sanitize_subset
-from delayedarray import is_sparse, extract_dense_array, extract_sparse_array, is_masked
+from delayedarray import is_sparse, extract_dense_array, extract_sparse_array, is_masked, chunk_grid, SimpleGrid, chunk_shape_to_grid
 
 __author__ = "ltla, jkanche"
 __copyright__ = "ltla, jkanche"
@@ -478,3 +478,8 @@ def extract_sparse_array_tatami(x: TatamiNumericPointer, subset: Tuple[Sequence[
 def is_masked_tatami(x: TatamiNumericPointer) -> bool:
     """See :py:meth:`~delayedarray.is_masked.is_masked`."""
     return False
+
+@chunk_grid.register
+def chunk_grid_tatami(x: TatamiNumericPointer) -> bool:
+    """See :py:meth:`~delayedarray.chunk_grid.chunk_grid`."""
+    return chunk_shape_to_grid((1, 1), x.shape, cost_factor=1)

--- a/src/mattress/interface.py
+++ b/src/mattress/interface.py
@@ -2,8 +2,9 @@ from functools import singledispatch
 from typing import Any
 
 import numpy as np
-import scipy.sparse as sp
 import delayedarray
+from biocutils.package_utils import is_package_installed
+
 
 from .TatamiNumericPointer import TatamiNumericPointer
 from . import _cpphelpers as lib
@@ -63,53 +64,55 @@ def _tatamize_numpy(x: np.ndarray) -> TatamiNumericPointer:
         obj=[x],
     )
 
+if is_package_installed("scipy"):
+    import scipy.sparse
 
-@tatamize.register
-def _tatamize_sparse_csr_array(x: sp.csr_array) -> TatamiNumericPointer:
-    tmp = x.indptr.astype(np.uint64, copy=False)
-    return TatamiNumericPointer(
-        ptr=lib.initialize_compressed_sparse_matrix(
-            x.shape[0],
-            x.shape[1],
-            len(x.data),
-            str(x.data.dtype).encode("UTF-8"),
-            x.data.ctypes.data,
-            str(x.indices.dtype).encode("UTF-8"),
-            x.indices.ctypes.data,
-            tmp.ctypes.data,
-            True,
-        ),
-        obj=[tmp, x],
-    )
-
-
-@tatamize.register
-def _tatamize_sparse_csr_matrix(x: sp.csr_matrix) -> TatamiNumericPointer:
-    return _tatamize_sparse_csr_array(x)
+    @tatamize.register
+    def _tatamize_sparse_csr_array(x: scipy.sparse.csr_array) -> TatamiNumericPointer:
+        tmp = x.indptr.astype(np.uint64, copy=False)
+        return TatamiNumericPointer(
+            ptr=lib.initialize_compressed_sparse_matrix(
+                x.shape[0],
+                x.shape[1],
+                len(x.data),
+                str(x.data.dtype).encode("UTF-8"),
+                x.data.ctypes.data,
+                str(x.indices.dtype).encode("UTF-8"),
+                x.indices.ctypes.data,
+                tmp.ctypes.data,
+                True,
+            ),
+            obj=[tmp, x],
+        )
 
 
-@tatamize.register
-def _tatamize_sparse_csc_array(x: sp.csc_array) -> TatamiNumericPointer:
-    tmp = x.indptr.astype(np.uint64, copy=False)
-    return TatamiNumericPointer(
-        ptr=lib.initialize_compressed_sparse_matrix(
-            x.shape[0],
-            x.shape[1],
-            len(x.data),
-            str(x.data.dtype).encode("UTF-8"),
-            x.data.ctypes.data,
-            str(x.indices.dtype).encode("UTF-8"),
-            x.indices.ctypes.data,
-            tmp.ctypes.data,
-            False,
-        ),
-        obj=[tmp, x],
-    )
+    @tatamize.register
+    def _tatamize_sparse_csr_matrix(x: scipy.sparse.csr_matrix) -> TatamiNumericPointer:
+        return _tatamize_sparse_csr_array(x)
 
 
-@tatamize.register
-def _tatamize_sparse_csc_matrix(x: sp.csc_matrix) -> TatamiNumericPointer:
-    return _tatamize_sparse_csc_array(x)
+    @tatamize.register
+    def _tatamize_sparse_csc_array(x: scipy.sparse.csc_array) -> TatamiNumericPointer:
+        tmp = x.indptr.astype(np.uint64, copy=False)
+        return TatamiNumericPointer(
+            ptr=lib.initialize_compressed_sparse_matrix(
+                x.shape[0],
+                x.shape[1],
+                len(x.data),
+                str(x.data.dtype).encode("UTF-8"),
+                x.data.ctypes.data,
+                str(x.indices.dtype).encode("UTF-8"),
+                x.indices.ctypes.data,
+                tmp.ctypes.data,
+                False,
+            ),
+            obj=[tmp, x],
+        )
+
+
+    @tatamize.register
+    def _tatamize_sparse_csc_matrix(x: scipy.sparse.csc_matrix) -> TatamiNumericPointer:
+        return _tatamize_sparse_csc_array(x)
 
 
 @tatamize.register

--- a/src/mattress/utils.py
+++ b/src/mattress/utils.py
@@ -1,5 +1,5 @@
 import os
-from typing import Union, Tuple, Sequence
+from typing import Union, Tuple, Sequence, List
 import assorthead
 import inspect
 import numpy as np
@@ -9,11 +9,11 @@ __copyright__ = "jkanche"
 __license__ = "MIT"
 
 
-def includes() -> list[str]:
+def includes() -> List[str]:
     """Provides access to C++ headers (including tatami) for downstream packages.
 
     Returns:
-        list[str]: List of paths to the header files.
+        List of paths to the header files.
     """
     dirname = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
     return [

--- a/tests/test_sparse.py
+++ b/tests/test_sparse.py
@@ -10,25 +10,25 @@ def test_sparse_csr_matrix():
     m = rand(3, 4, density=0.25, format="csr", random_state=42)
     ptr = tatamize(m)
     assert all(ptr.row(0) == m[0, :].toarray()[0])
-    assert all(ptr.column(1) == m[:, 1].toarray()[0])
+    assert all(ptr.column(1) == m[:, 1].toarray().flatten())
 
 
 def test_sparse_csr_array():
     m = rand(3, 4, density=0.25, format="csr", random_state=42).tocsr()
     ptr = tatamize(m)
     assert all(ptr.row(0) == m[0, :].toarray()[0])
-    assert all(ptr.column(1) == m[:, 1].toarray()[0])
+    assert all(ptr.column(1) == m[:, 1].toarray().flatten())
 
 
 def test_sparse_csc_matrix():
     m = rand(3, 4, density=0.25, format="csc", random_state=42)
     ptr = tatamize(m)
     assert all(ptr.row(0) == m[0, :].toarray()[0])
-    assert all(ptr.column(1) == m[:, 1].toarray()[0])
+    assert all(ptr.column(1) == m[:, 1].toarray().flatten())
 
 
 def test_sparse_csc_array():
     m = rand(3, 4, density=0.25, format="csc", random_state=42).tocsc()
     ptr = tatamize(m)
     assert all(ptr.row(0) == m[0, :].toarray()[0])
-    assert all(ptr.column(1) == m[:, 1].toarray()[0])
+    assert all(ptr.column(1) == m[:, 1].toarray().flatten())


### PR DESCRIPTION
- Implement new `DelayedArray` generics; also bump to the newer version
- scipy's `toarray` does not flatten 1 dimensional vectors anymore, update tests to adapt to this change.
- scipy is now an optional dependency and all generics are registered only if `scipy` is installed. 
